### PR TITLE
Slight language improvements to address mistakes/ambiguities in the privacy statements

### DIFF
--- a/Pages/Privacy.cshtml
+++ b/Pages/Privacy.cshtml
@@ -8,8 +8,8 @@
 <h1 style="color: green; padding-bottom: 15px; padding-top: 15px;">@ViewData["Title"]</h1>
 <div class="container">
 
-    Your privacy is important to us. This privacy statement explains the personal data Woodgrove groceries demo
-    application processes, how we processes it, and for what purposes.
+    Your privacy is important to us. This privacy statement explains the personal data processed by the Woodgrove Groceries demo
+    application, how we process it, and for what purposes.
 
     <h3 style="padding-top: 25px;">Personal data we collect</h3>
     <ul>
@@ -58,7 +58,7 @@
     <h3 style="padding-top: 25px; padding-bottom: 10px;">Social account</h3>
 
     Social or enterprise login uses information from social or enterprise identity providers, such as Microsoft,
-    Facebook and Google accounts to facilitate logins to the Woodgrove groceries live demo application. This simplifies
+    Facebook and Google accounts to facilitate logins to the Woodgrove Groceries live demo application. This simplifies
     registrations and sign-in for you. Social or enterprise identities are managed by a federated identity provider.
     Microsoft Entra External ID stores additional information about your account, such as display name, first name, and
     last name. Microsoft Entra External ID also stores the social or enterprise unique identifier that is linked to your
@@ -66,16 +66,16 @@
 
     <h3 style="padding-top: 25px; padding-bottom: 10px;">Accounts clean up</h3>
 
-    As users try this demo application, it’s possible that many accounts get created in the Microsoft Entra External ID
+    As users try this demo application, it’s possible that an excess number of accounts will be created in the Microsoft Entra External ID
     tenant over time. When users no longer access the demo application (using last interactive and non-interactive
-    sign-in date and time), the accounts may be deleted automatically from the directory. If you account has been
+    sign-in date and time), these inactive accounts may be deleted automatically from the directory. If you account has been
     deleted, you will have to sign-up again.
 
     <h3 style="padding-top: 25px; padding-bottom: 10px;">Delete your account</h3>
 
-    Use this link to <a asp-area="" asp-page="/DeleteMyAccount">delete your account</a>. Your
-     account will be permanently deleted (it will be removed from the recycle bin immediately) along with your personal information you provided us.
+    You can delete your account at anytime using <a asp-area="" asp-page="/DeleteMyAccount">this link</a>. Your
+     account will be permanently deleted (it will be removed from the recycle bin immediately) along with any personal information you have provided.
     Sign-in logs will remain in our system for <a
-                href="https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-reports-data-retention#how-long-does-azure-ad-store-the-data">Seven days</a>.
+                href="https://learn.microsoft.com/en-us/entra/identity/monitoring-health/reference-reports-data-retention#how-long-does-azure-ad-store-the-data">seven days</a>.
     </li>
 </div>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project welcomes contributions and suggestions. [Learn how to contribue to 
 
 ## Privacy policy and terms of service
 
-Your privacy is important to us. Our [privacy statement](https://woodgrovedemo.com/Privacy) explains the personal data Woodgrove groceries demo application processes, how we processes it, and for what purposes. We aslo recommand you to check out our [terms of service](https://woodgrovedemo.com/TOS).
+Your privacy is important to us. Our [privacy statement](https://woodgrovedemo.com/Privacy) explains the personal data processed by the Woodgrove Groceries demo application, how we process it, and for what purposes. We also recommend that you check out our [terms of service](https://woodgrovedemo.com/TOS).
 
 
 


### PR DESCRIPTION
Just a few simple corrections of incorrect capitalisation or sentence structure in the `/Privacy` page and `README.md`. There revisions shouldn't change any meaning to the policy, rather just improve the flow and correct some basic mistakes. Not sure if these need to be reviewed by MS Legal or if they can be pushed as just superficial improvements?