### PR TITLE
Multi scheme auth + email OTP demo

### DIFF
--- a/Controllers/SelectUseCaseController.cs
+++ b/Controllers/SelectUseCaseController.cs
@@ -27,7 +27,7 @@ public class SelectUseCaseController : ControllerBase
     [HttpGet("usecase")]
     public IActionResult RecordUseCase(string ID, string trigger, string referral = null)
     {
-        string[] useCases = { "Default", "SignUpLink", "CustomDomain", "CustomEmail", "AssignmentRequired", "OnlineRetail", "StepUp", "CSA", "PolicyAgreement", "EmailAndPassword", "DisableAccount", "OBO", "SSO", "TokenTTL", "MFA", "CA", "ForceSignIn", "UserInsights", "ModifyAttributeValues", "BlockSignUp", "CompanyBranding", "Language", "PreSelectLanguage", "SSPR", "Social", "ActAs", "LoginHint", "TokenAugmentation", "GithubWorkflows", "TokenClaims", "PreAttributeCollection", "PostAttributeCollection", "ProfileEdit", "DeleteAccount", "UserLastActivity", "RBAC", "GBAC", "CustomAttributes", "Kiosk", "Finance" };
+        string[] useCases = { "Default", "SignUpLink", "EmailOtp", "CustomDomain", "CustomEmail", "AssignmentRequired", "OnlineRetail", "StepUp", "CSA", "PolicyAgreement", "EmailAndPassword", "DisableAccount", "OBO", "SSO", "TokenTTL", "MFA", "CA", "ForceSignIn", "UserInsights", "ModifyAttributeValues", "BlockSignUp", "CompanyBranding", "Language", "PreSelectLanguage", "SSPR", "Social", "ActAs", "LoginHint", "TokenAugmentation", "GithubWorkflows", "TokenClaims", "PreAttributeCollection", "PostAttributeCollection", "ProfileEdit", "DeleteAccount", "UserLastActivity", "RBAC", "GBAC", "CustomAttributes", "Kiosk", "Finance" };
         string[] triggers = { "Link", "Start", "Select" };
 
         string referralDomain = string.Empty;

--- a/Models/AuthScheme.cs
+++ b/Models/AuthScheme.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+
+public class AuthScheme
+{
+    public const string ArkoseFraudProtection = "ArkoseFraudProtection";
+    public const string EmailOtp = "EmailOtp";
+
+    public static string[] All
+    {
+        get
+        {
+            return new string[] {
+            OpenIdConnectDefaults.AuthenticationScheme,
+                AuthScheme.ArkoseFraudProtection,
+                AuthScheme.EmailOtp };
+        }
+    }
+}

--- a/Pages/Shared/AboutThisDemoPartial.cshtml
+++ b/Pages/Shared/AboutThisDemoPartial.cshtml
@@ -23,9 +23,12 @@
                 <h6 class="dropdown-header" style="color: var(--color-very-dark);">Sign-in</h6>
             </li>
 
-            <li><a class="dropdown-item" href="#usecase=EmailAndPassword"><i class="bi bi-at"></i>&nbsp;
+            <li><a class="dropdown-item" href="#usecase=EmailAndPassword"><i class="bi-chat-right-dots"></i>&nbsp;
                     Sign-up or sign-in with email
                     and password</a></li>
+            <li><a class="dropdown-item" href="#usecase=EmailOtp"><i class="bi bi-at"></i>&nbsp;
+                    Sign-up or sign-in with email
+                    and one-time passcode</a></li>
             <li><a class="dropdown-item" href="#usecase=SSPR"><i class="bi bi-key"></i>&nbsp; Self-service
                     password reset</a></li>
             <li><a class="dropdown-item" href="#usecase=Social"><i class="bi bi-facebook"></i>&nbsp; Sign-up or sign-in
@@ -268,6 +271,34 @@
                 <i class="bi bi-play-circle"></i> <a class="" style="margin-top: 100px;" role="button"
                     href="/help/EmailAndPassword">
                     Learn how we configured the Woodgrove tenant</a>
+            </div>
+
+            <div id="useCase_EmailOtp" class="useCase">
+                <h4>Sign-up or sign-in with email and one-time passcode</h4>
+
+                <h5>Create a new Woodgrove account</h5>
+                <ol>
+                    <li>Select the <b>start the use case</b> button at the bottom of this page.</li>
+                    <li>From the sign-in page select <b>No account? Create one.</b></li>
+                    <li>Enter your email address, which will be verified and becomes your login ID.</li>
+                    <li>Open your mailbox and copy the verification code sent to you. Then, on the sign-in
+                        page enter the verification code and select <b>next</b>.</li>
+                    <li>After the email was verified, 
+                        and enter your account details. Notice, that passsword is not required.</li>
+                    <li>Select <b>next</b> to complete the registration.</li>
+                </ol>
+
+                <h5>Sign-in with your Woodgrove account</h5>
+                <ol>
+                    <li>Select the <b>start the use case</b> button at the bottom of this page.</li>
+                    <li>On the sign-in page, enter your email, and select <b>next</b>.</li>
+                    <li>Open your mailbox and copy the verification code sent to you. Then, on the sign-in
+                        page enter the verification code and select <b>next</b>.</li>
+                </ol>
+
+                <a class="btn header-button" role="button" href="/SignIn?handler=EmailOtp"><i
+                        class="bi bi-play-circle"></i> Start the use
+                    case</a>
             </div>
 
             <div id="useCase_CompanyBranding" class="useCase">

--- a/Pages/Shared/_LoginPartial.cshtml
+++ b/Pages/Shared/_LoginPartial.cshtml
@@ -1,4 +1,5 @@
 ﻿@using System.Security.Principal
+@using Microsoft.AspNetCore.Authentication.OpenIdConnect
 @using Microsoft.Extensions.Configuration
 @inject IConfiguration Configuration
 
@@ -50,9 +51,12 @@
 
 @if (User.Identity?.IsAuthenticated == true)
 {   
-    <li class="nav-item">
-        <a class="nav-link header-button" href="/profile"><i class="bi bi-person-fill"></i> Profile</a>
-    </li>
+    @if (User.Claims.FirstOrDefault(c => c.Type == "AuthScheme")?.Value == OpenIdConnectDefaults.AuthenticationScheme)
+    {
+        <li class="nav-item">
+            <a class="nav-link header-button" href="/profile"><i class="bi bi-person-fill"></i> Profile</a>
+        </li>
+    }
     <li class="nav-item woodgrove-nav-space">
         <div style="width: 10px;"></div>
     </li>

--- a/Pages/SignIn.cshtml.cs
+++ b/Pages/SignIn.cshtml.cs
@@ -37,8 +37,15 @@ namespace MyApp.Namespace
         {
             _telemetry.TrackPageView($"Sign-in:{ID}");
 
+            // Set the authentication scheme
+            string authenticationScheme = OpenIdConnectDefaults.AuthenticationScheme;
+            // if (ID == AuthScheme.ArkoseFraudProtection)
+            // {
+            //     authenticationScheme = AuthScheme.ArkoseFraudProtection;
+            // }
+
             ChallengeResult challengeResult = new ChallengeResult(
-                OpenIdConnectDefaults.AuthenticationScheme,
+                authenticationScheme,
                 new AuthenticationProperties
                 {
                     RedirectUri = redirectUri
@@ -88,6 +95,16 @@ namespace MyApp.Namespace
         public IActionResult OnGetDefault()
         {
             return this.TrackAndAuth("Default");
+        }
+
+        public IActionResult OnGetArkoseFraudProtection()
+        {
+            return this.TrackAndAuth("ArkoseFraudProtection");
+        }
+        
+        public IActionResult OnGetEmailOtp()
+        {
+            return this.TrackAndAuth("EmailOtp");
         }
 
         public IActionResult OnGetModifyAttributeValues()
@@ -195,7 +212,7 @@ namespace MyApp.Namespace
         {
             return this.TrackAndAuth("ProfileReauth", "/profile");
         }
-        
+
         public IActionResult OnGetEmailAndPassword()
         {
             return this.TrackAndAuth("EmailAndPassword", "/", true);
@@ -290,7 +307,7 @@ namespace MyApp.Namespace
         {
             return this.TrackAndAuth("SSPR", "/", true);
         }
-        
+
         public IActionResult OnGetCustomAttributes()
         {
             return this.TrackAndAuth("CustomAttributes", "/", true);

--- a/Pages/SignOut.cshtml.cs
+++ b/Pages/SignOut.cshtml.cs
@@ -21,6 +21,17 @@ namespace MyApp.Namespace
 
             _telemetry.TrackPageView("SignOut");
 
+            foreach (var cookie in Request.Cookies.Keys)
+            {
+                foreach (var scheme in AuthScheme.All)
+                {
+                    if (cookie.Contains(scheme))
+                    {
+                        Response.Cookies.Delete(cookie);
+                    }
+                }
+            }
+
             return Redirect("/MicrosoftIdentity/Account/SignOut");
         }
     }

--- a/Pages/Token.cshtml
+++ b/Pages/Token.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using Microsoft.AspNetCore.Authentication.OpenIdConnect
 @model woodgrovedemo.Pages.TokenModel
 @{
 }
@@ -27,10 +28,13 @@
 
             @foreach (var claim in User.Claims)
             {
-                <tr>
-                    <td scope="row" style="color: #1b1b1b;">@claim.Type</td>
-                    <td class="text-break">@claim.Value</td>
-                </tr>
+                if (claim.Type != "AuthScheme")
+                {
+                    <tr>
+                        <td scope="row" style="color: #1b1b1b;">@claim.Type</td>
+                        <td class="text-break">@claim.Value</td>
+                    </tr>
+                }
             }
         </tbody>
     </table>
@@ -42,50 +46,54 @@
                 <li>The <a href='https://jwt.ms/#access_token=@Model.IdToken.Replace("Bearer ", "")'
                         target="_blank">https://jwt.ms</a> shows the ID token.</li>
                 <li>@Model.IdTokenExpiresIn</li>
+                <li>Auth scheme: @Model.AuthScheme</li>
             </ul>
         }
     </div>
 
-    <h2 style="color: green;">Access token to call web API</h2>
-    <div>
+    @if (Model.AuthScheme == OpenIdConnectDefaults.AuthenticationScheme)
+    {
+        <h2 style="color: green;">Access token to call web API</h2>
+        <div>
 
-        @if (!string.IsNullOrEmpty(@Model.AccessToken))
-        {
-            <span>The <a href='https://jwt.ms/#access_token=@Model.AccessToken.Replace("Bearer ", "")'
-                    target="_blank">https://jwt.ms</a> shows the access token used to call a web API (Account API).</span>
-        }
+            @if (!string.IsNullOrEmpty(@Model.AccessToken))
+            {
+                <span>The <a href='https://jwt.ms/#access_token=@Model.AccessToken.Replace("Bearer ", "")'
+                        target="_blank">https://jwt.ms</a> shows the access token used to call a web API (Account API).</span>
+            }
 
-        @if (!string.IsNullOrEmpty(@Model.AccessTokenError))
-        {
-            <div class="alert alert-danger" role="alert">
-                @Model.AccessTokenError
-            </div>
-        }
+            @if (!string.IsNullOrEmpty(@Model.AccessTokenError))
+            {
+                <div class="alert alert-danger" role="alert">
+                    @Model.AccessTokenError
+                </div>
+            }
 
-        <br>&nbsp;<br>
+            <br>&nbsp;<br>
 
 
-        @if (!string.IsNullOrEmpty(@Model.DownstreamAccessToken))
-        {
-            <span>
-                For the <b>Account </b>API to make authenticated requests to the downstream <b>Payment</b> API, it needs an
-                access token for different audience and another set of scopes (permissions). To get that access token, the
-                <b>Account</b> API utilizes the OAuth 2.0 On-Behalf-Of flow.
+            @if (!string.IsNullOrEmpty(@Model.DownstreamAccessToken))
+            {
+                <span>
+                    For the <b>Account </b>API to make authenticated requests to the downstream <b>Payment</b> API, it needs an
+                    access token for different audience and another set of scopes (permissions). To get that access token, the
+                    <b>Account</b> API utilizes the OAuth 2.0 On-Behalf-Of flow.
 
-            </span>
-            <span>The <a href='https://jwt.ms/#access_token=@Model.DownstreamAccessToken.Replace("Bearer ", "")'
-                    target="_blank">https://jwt.ms</a> shows the access token acquired by the <b>Account</b> API to call the
-                downstream <b>Payment</b> API.</span>
-        }
+                </span>
+                <span>The <a href='https://jwt.ms/#access_token=@Model.DownstreamAccessToken.Replace("Bearer ", "")'
+                        target="_blank">https://jwt.ms</a> shows the access token acquired by the <b>Account</b> API to call the
+                    downstream <b>Payment</b> API.</span>
+            }
 
-        @if (!string.IsNullOrEmpty(@Model.DownstreamAccessTokenError))
-        {
-            <div class="alert alert-danger" role="alert">
-                @Model.DownstreamAccessTokenError
-            </div>
-        }
+            @if (!string.IsNullOrEmpty(@Model.DownstreamAccessTokenError))
+            {
+                <div class="alert alert-danger" role="alert">
+                    @Model.DownstreamAccessTokenError
+                </div>
+            }
 
-    </div>
+        </div>
+    }
 
     <a class="btn header-button" role="button" href="/SignIn?handler=TokenSignin"><i class="bi bi-person"></i>
         Sign-in with SSO</a>

--- a/appsettings.json
+++ b/appsettings.json
@@ -36,6 +36,32 @@
       }
     ]
   },
+  "ArkoseFraudProtection": {
+    "Authority": "https://your-tenant.ciamlogin.com/",
+    "ClientId": "22222222-0000-0000-00000000000000000",
+    "CallbackPath": "/signin-ArkoseFraudProtection",
+    "SignedOutCallbackPath": "/signout-ArkoseFraudProtection",
+    "ClientCertificates": [
+      {
+        "SourceType": "StoreWithThumbprint",
+        "CertificateStorePath": "CurrentUser/My",
+        "CertificateThumbprint": "<Your certificate thumbprint>"
+      }
+    ]
+  },
+  "EmailOtp": {
+    "Authority": "https://your-tenant.ciamlogin.com/",
+    "ClientId": "33333333-0000-0000-00000000000000000",
+    "CallbackPath": "/signin-EmailOtp",
+    "SignedOutCallbackPath": "/signout-EmailOtp",
+    "ClientCertificates": [
+      {
+        "SourceType": "StoreWithThumbprint",
+        "CertificateStorePath": "CurrentUser/My",
+        "CertificateThumbprint": "<Your certificate thumbprint>"
+      }
+    ]
+  },
   "MicrosoftGraph": {
     "TenantId": "22222222-2222-2222-2222-222222222222",
     "ClientId": "55555555-0000-0000-00000000000000000",

--- a/woodgrovedemo.csproj
+++ b/woodgrovedemo.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-woodgrovedemo-FBF1B85E-DADD-4187-9E01-DBB8923E80F7</UserSecretsId>
-    <AssemblyVersion>1.0.0.26</AssemblyVersion>
+    <AssemblyVersion>1.0.2.1</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/wwwroot/js/site.js
+++ b/wwwroot/js/site.js
@@ -77,7 +77,7 @@ function showUseCase(trigger) {
         usecase = 'Default';
     }
 
-    var useCases = ["Default", "SignUpLink", "OnlineRetail", "DisableAccount", "CustomDomain", "CustomEmail", "AssignmentRequired", "StepUp", "CSA", "PolicyAgreement", "EmailAndPassword", "OBO", "SSO", "GithubWorkflows", "TokenTTL", "MFA", "CA", "ForceSignIn", "UserInsights", "SignInLog", "ModifyAttributeValues", "BlockSignUp", "CompanyBranding", "Language", "PreSelectLanguage", "SSPR", "Social", "ActAs", "LoginHint", "TokenAugmentation", "TokenClaims", "PreAttributeCollection", "PostAttributeCollection", "ProfileEdit", "DeleteAccount", "UserLastActivity", "RBAC", "GBAC", "CustomAttributes", "Kiosk", "Finance"];
+    var useCases = ["Default", "SignUpLink", "EmailOtp", "OnlineRetail", "DisableAccount", "CustomDomain", "CustomEmail", "AssignmentRequired", "StepUp", "CSA", "PolicyAgreement", "EmailAndPassword", "OBO", "SSO", "GithubWorkflows", "TokenTTL", "MFA", "CA", "ForceSignIn", "UserInsights", "SignInLog", "ModifyAttributeValues", "BlockSignUp", "CompanyBranding", "Language", "PreSelectLanguage", "SSPR", "Social", "ActAs", "LoginHint", "TokenAugmentation", "TokenClaims", "PreAttributeCollection", "PostAttributeCollection", "ProfileEdit", "DeleteAccount", "UserLastActivity", "RBAC", "GBAC", "CustomAttributes", "Kiosk", "Finance"];
 
     if (($('#offcanvasRight').length > 0) && usecase && (useCases.indexOf(usecase) > -1)) {
 


### PR DESCRIPTION
This pull request establishes the groundwork for demonstrations that require using a dedicated application registration (rather than the default Woodgrove app registration). It introduces support for multiple authentication schemes, including an email and OTP demo, as well as a placeholder for the ArkoseFraudProtection demo.

In this version, the non-default demos are restricted and cannot access the profile page or certain sections of the token page. The current user's authentication scheme is now included in the claims, allowing you to identify which authentication scheme is being utilized.
