### PR TITLE
Refactor user group membership check

### DIFF
--- a/Controllers/UserRolesController.cs
+++ b/Controllers/UserRolesController.cs
@@ -46,6 +46,17 @@ public class UserRolesController : ControllerBase
         var groups = await graphClient.Users[userObjectId].MemberOf.GetAsync();
         foreach (var group in groups.Value)
         {
+            try
+            {
+                //if (((Group)group).DisplayName == "Commercial accounts")
+                if (((Group)group).Id == _configuration.GetSection("AppRoles:CommercialAccountsSecurityGroup").Value)
+                {
+                    userRoles.MemberOfCommercialAccounts = true;
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
 
             if (((Group)group).DisplayName == "Commercial accounts")
             {


### PR DESCRIPTION
Updated the condition for verifying user membership in the "Commercial accounts" group. The check now uses the group's ID from configuration settings instead of a hardcoded display name, enhancing flexibility and maintainability.